### PR TITLE
Fix Next.js font loader usage in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,12 +6,29 @@ import { Suspense } from "react"
 import { CookieBanner } from "@/components/cookie-banner"
 import "./globals.css"
 
-import { Geist as V0_Font_Geist, Geist_Mono as V0_Font_Geist_Mono, Source_Serif_4 as V0_Font_Source_Serif_4 } from 'next/font/google'
+import {
+  Geist as V0_Font_Geist,
+  Geist_Mono as V0_Font_Geist_Mono,
+  Source_Serif_4 as V0_Font_Source_Serif_4,
+} from "next/font/google"
 
-// Initialize fonts
-V0_Font_Geist({ weight: ["100","200","300","400","500","600","700","800","900"] })
-V0_Font_Geist_Mono({ weight: ["100","200","300","400","500","600","700","800","900"] })
-V0_Font_Source_Serif_4({ weight: ["200","300","400","500","600","700","800","900"] })
+const geistSans = V0_Font_Geist({
+  subsets: ["latin"],
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+  variable: "--font-geist-sans",
+})
+
+const geistMono = V0_Font_Geist_Mono({
+  subsets: ["latin"],
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+  variable: "--font-geist-mono",
+})
+
+const sourceSerif = V0_Font_Source_Serif_4({
+  subsets: ["latin"],
+  weight: ["200", "300", "400", "500", "600", "700", "800", "900"],
+  variable: "--font-source-serif",
+})
 
 export const metadata: Metadata = {
   title: {
@@ -80,7 +97,10 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable} ${sourceSerif.variable}`}
+    >
       <head>
         <Script
           id="gtm-script"


### PR DESCRIPTION
## Summary
- initialize Google fonts through Next.js font loaders at module scope using CSS variables
- apply the generated font CSS variables on the html element so Tailwind can use the configured fonts

## Testing
- pnpm run lint *(fails: prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68da7dff94208323a546842ec819d67d