### PR TITLE
Fix font loader setup in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,17 +6,17 @@ import { Suspense } from "react"
 import { CookieBanner } from "@/components/cookie-banner"
 import "./globals.css"
 
-import { Geist as V0_Font_Geist, Geist_Mono as V0_Font_Geist_Mono, Source_Serif_4 as V0_Font_Source_Serif_4 } from 'next/font/google'
-import { Geist as V0_Font_Geist, Geist_Mono as V0_Font_Geist_Mono, Source_Serif_4 as V0_Font_Source_Serif_4 } from 'next/font/google'
+import { GeistSans as V0_Font_Geist } from "geist/font/sans"
+import { GeistMono as V0_Font_Geist_Mono } from "geist/font/mono"
+import { Source_Serif_4 as V0_Font_Source_Serif_4 } from "next/font/google"
 
-// Initialize fonts
-V0_Font_Geist({ weight: ["100","200","300","400","500","600","700","800","900"] })
-V0_Font_Geist_Mono({ weight: ["100","200","300","400","500","600","700","800","900"] })
-V0_Font_Source_Serif_4({ weight: ["200","300","400","500","600","700","800","900"] })
-
-const geistFont = V0_Font_Geist({ weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"] })
-const geistMonoFont = V0_Font_Geist_Mono({ weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"] })
-const sourceSerifFont = V0_Font_Source_Serif_4({ weight: ["200", "300", "400", "500", "600", "700", "800", "900"] })
+const geistFont = V0_Font_Geist
+const geistMonoFont = V0_Font_Geist_Mono
+const sourceSerifFont = V0_Font_Source_Serif_4({
+  weight: ["200", "300", "400", "500", "600", "700", "800", "900"],
+  subsets: ["latin"],
+  variable: "--font-source-serif-4",
+})
 
 export const metadata: Metadata = {
   title: {
@@ -101,7 +101,9 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body className={`font-sans ${geistFont.variable} ${geistMonoFont.variable}`}>
+      <body
+        className={`font-sans ${geistFont.variable} ${geistMonoFont.variable} ${sourceSerifFont.variable}`}
+      >
         <noscript>
           <iframe
             src="https://www.googletagmanager.com/ns.html?id=GTM-WBZTTZ66"


### PR DESCRIPTION
## Summary
- replace duplicated Google font imports by using the Geist font package
- configure Source Serif 4 loader once at module scope and apply all font variables on the layout body

## Testing
- pnpm run build *(fails: unable to download Google font in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da8552406c8323a39564eaca611eff