### PR TITLE
Fix Geist font import usage and remove unsupported border utility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -124,7 +124,8 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--border);
+    outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
   }
   body {
     @apply bg-background text-foreground;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,13 +6,6 @@ import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
 import "./globals.css"
 
-import { Geist as V0_Font_Geist, Geist_Mono as V0_Font_Geist_Mono, Source_Serif_4 as V0_Font_Source_Serif_4 } from 'next/font/google'
-
-// Initialize fonts
-V0_Font_Geist({ weight: ["100","200","300","400","500","600","700","800","900"] })
-V0_Font_Geist_Mono({ weight: ["100","200","300","400","500","600","700","800","900"] })
-V0_Font_Source_Serif_4({ weight: ["200","300","400","500","600","700","800","900"] })
-
 export const metadata: Metadata = {
   title: "WEESS Mieterstrom - Mehr verdienen, weniger Aufwand",
   description:
@@ -23,7 +16,7 @@ export const metadata: Metadata = {
     description: "WEESS vereinfacht Mieterstrom für jeden Installateur.",
     type: "website",
   },
-    generator: 'v0.app'
+  generator: "v0.app",
 }
 
 export default function RootLayout({
@@ -32,8 +25,8 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="de">
-      <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable} antialiased`}>
+    <html lang="de" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <body className="font-sans antialiased">
         <Suspense fallback={null}>{children}</Suspense>
         <Analytics />
       </body>

--- a/components/comparison-section.tsx
+++ b/components/comparison-section.tsx
@@ -66,7 +66,7 @@ export function ComparisonSection() {
             </div>
 
             {/* Klassische Vollversorgung */}
-            <div className="glass-card rounded-3xl p-8 md:p-10 border-2 border-border hover-lift shadow-xl">
+            <div className="glass-card rounded-3xl p-8 md:p-10 border-2 hover-lift shadow-xl">
               <div className="flex items-center gap-4 mb-8">
                 <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-muted to-muted/80 flex items-center justify-center text-3xl">
                   ⚙️

--- a/components/faq-section.tsx
+++ b/components/faq-section.tsx
@@ -52,7 +52,7 @@ export function FAQSection() {
               <AccordionItem
                 key={index}
                 value={`item-${index}`}
-                className="bg-card border border-border rounded-lg px-6"
+                className="bg-card border rounded-lg px-6"
               >
                 <AccordionTrigger className="text-left font-semibold text-foreground hover:text-primary">
                   {faq.question}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 
 export function Footer() {
   return (
-    <footer className="bg-muted/30 border-t border-border py-12">
+    <footer className="bg-muted/30 border-t py-12">
       <div className="container mx-auto px-4">
         <div className="flex flex-col items-center gap-6">
           <Image src="/images/weess-logo.png" alt="WEESS Logo" width={100} height={35} className="h-8 w-auto" />

--- a/components/problem-solution-section.tsx
+++ b/components/problem-solution-section.tsx
@@ -36,7 +36,7 @@ export function ProblemSolutionSection() {
 
           <div className="space-y-8">
             {problems.map((item, index) => (
-              <div key={index} className="bg-card rounded-lg shadow-md p-6 md:p-8 border border-border">
+              <div key={index} className="bg-card rounded-lg shadow-md p-6 md:p-8 border">
                 <div className="grid md:grid-cols-2 gap-6">
                   {/* Problem */}
                   <div className="space-y-3">
@@ -48,7 +48,7 @@ export function ProblemSolutionSection() {
                   </div>
 
                   {/* Solution */}
-                  <div className="space-y-3 md:border-l md:border-border md:pl-6">
+                  <div className="space-y-3 md:border-l md:pl-6">
                     <div className="flex items-start gap-3">
                       <span className="text-primary text-2xl leading-none">✓</span>
                       <h3 className="text-xl font-semibold text-primary">{item.solution}</h3>

--- a/components/vision-section.tsx
+++ b/components/vision-section.tsx
@@ -9,15 +9,15 @@ export function VisionSection() {
           </p>
 
           <div className="grid md:grid-cols-3 gap-6 pt-8">
-            <div className="bg-card p-6 rounded-lg shadow-sm border border-border">
+            <div className="bg-card p-6 rounded-lg shadow-sm border">
               <h3 className="text-lg font-semibold text-foreground mb-3">Energiewende vorantreiben</h3>
               <p className="text-muted-foreground">Gemeinsam gestalten wir eine nachhaltige Zukunft</p>
             </div>
-            <div className="bg-card p-6 rounded-lg shadow-sm border border-border">
+            <div className="bg-card p-6 rounded-lg shadow-sm border">
               <h3 className="text-lg font-semibold text-foreground mb-3">Einfachen Zugang schaffen</h3>
               <p className="text-muted-foreground">Mieterstrom für jeden zugänglich machen</p>
             </div>
-            <div className="bg-card p-6 rounded-lg shadow-sm border border-border">
+            <div className="bg-card p-6 rounded-lg shadow-sm border">
               <h3 className="text-lg font-semibold text-foreground mb-3">Nachhaltigkeit verbinden</h3>
               <p className="text-muted-foreground">Wirtschaftlichkeit und Komfort in Einklang bringen</p>
             </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -117,7 +117,8 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--border);
+    outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
## Summary
- clean up the root layout to rely on the official GeistSans/GeistMono exports without manual initialization
- replace uses of the unsupported `border-border` Tailwind utility with CSS-based styling so the build no longer fails

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dbc173275c83239630da146dd8e20e