### PR TITLE
Fix Next.js build by removing invalid Geist font import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,13 +8,11 @@ import "./globals.css"
 
 import { GeistSans, GeistMono } from "geist/font"
 
-import { Source_Serif_4, Geist as V0_Font_Geist, Geist_Mono as V0_Font_Geist_Mono, Source_Serif_4 as V0_Font_Source_Serif_4 } from 'next/font/google'
+import { Source_Serif_4, Source_Serif_4 as V0_Font_Source_Serif_4 } from 'next/font/google'
 
 // Initialize fonts
-const _geist = V0_Font_Geist({ subsets: ['latin'], weight: ["100","200","300","400","500","600","700","800","900"], variable: '--v0-font-geist' })
-const _geistMono = V0_Font_Geist_Mono({ subsets: ['latin'], weight: ["100","200","300","400","500","600","700","800","900"], variable: '--v0-font-geist-mono' })
 const _sourceSerif_4 = V0_Font_Source_Serif_4({ subsets: ['latin'], weight: ["200","300","400","500","600","700","800","900"], variable: '--v0-font-source-serif-4' })
-const _v0_fontVariables = `${_geist.variable} ${_geistMono.variable} ${_sourceSerif_4.variable}`
+const _v0_fontVariables = `${_sourceSerif_4.variable}`
 
 const sourceSerif = Source_Serif_4({
   subsets: ["latin"],


### PR DESCRIPTION
## Summary
- remove the invalid Geist/Geist Mono imports from `next/font/google` to keep the layout font setup compatible with Next.js

## Testing
- pnpm run build *(fails locally: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee6d98a14c832397d29eed646677e4