### PR TITLE
Embed new funnel as primary /anfrage (classic form → /anfrage/klassisch)

### DIFF
--- a/app/anfrage/klassisch/page.tsx
+++ b/app/anfrage/klassisch/page.tsx
@@ -1,0 +1,26 @@
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { AnfrageContent } from "../anfrage-content"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Anfrage (klassisches Formular) - fairmieterstrom",
+  description:
+    "Klassisches Anfrageformular für fairmieterstrom – Intake-Formular und Terminbuchung auf einer Seite.",
+  alternates: {
+    canonical: "https://fairmieterstrom.energy/anfrage/klassisch",
+  },
+}
+
+// Preserved single-page intake + booking experience. The primary /anfrage now
+// embeds the new multi-step funnel (www.fairmieterstrom.app/funnel); this
+// classic form stays available as a subpage.
+export default function AnfrageKlassischPage() {
+  return (
+    <main className="min-h-screen bg-[#f3eee7]">
+      <Navbar />
+      <AnfrageContent />
+      <Footer />
+    </main>
+  )
+}

--- a/app/anfrage/page.tsx
+++ b/app/anfrage/page.tsx
@@ -1,6 +1,4 @@
 import { Navbar } from "@/components/navbar"
-import { Footer } from "@/components/footer"
-import { AnfrageContent } from "./anfrage-content"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -12,12 +10,31 @@ export const metadata: Metadata = {
   },
 }
 
+// The primary Anfrage experience is now the new multi-step funnel hosted by the
+// dashboard app (www.fairmieterstrom.app/funnel), embedded here as an iframe.
+// The previous single-page intake + booking form is preserved at
+// /anfrage/klassisch. Navbar is sticky (h-16); the iframe fills the viewport
+// below it and scrolls internally.
 export default function AnfragePage() {
   return (
-    <main className="min-h-screen bg-[#f3eee7]">
+    <main className="min-h-screen bg-[#04252b]">
       <Navbar />
-      <AnfrageContent />
-      <Footer />
+      <iframe
+        src="https://www.fairmieterstrom.app/funnel"
+        title="fairMieterstrom – Anfrage"
+        className="block w-full border-0 h-[calc(100dvh-4rem)] min-h-[640px]"
+        loading="eager"
+        allow="clipboard-write"
+      />
+      <noscript>
+        <p className="p-6 text-center text-white">
+          Bitte aktivieren Sie JavaScript – oder nutzen Sie das{" "}
+          <a href="/anfrage/klassisch" className="underline">
+            klassische Anfrageformular
+          </a>
+          .
+        </p>
+      </noscript>
     </main>
   )
 }


### PR DESCRIPTION
## What
- **/anfrage** now embeds the new multi-step funnel (`www.fairmieterstrom.app/funnel`) via a full-viewport iframe under the navbar.
- The previous single-page **IntakeWidget + BookingWidget** experience is preserved at **/anfrage/klassisch** (nothing removed; booking still available there).

## Notes
- Iframe fills `calc(100dvh - 4rem)` below the sticky navbar; scrolls internally.
- The .app `/funnel` has no X-Frame-Options, so framing is allowed.
- ⚠️ The funnel's **address autocomplete** step will stay broken until Google Maps **billing** is re-enabled on `peg-dashboard-prod` (separate blocker — not a regression from this PR).

## Review
Check the Vercel preview deployment for this branch, then merge if good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)